### PR TITLE
Add motherboard associations support for PCIe devs

### DIFF
--- a/include/mdrv2.hpp
+++ b/include/mdrv2.hpp
@@ -30,3 +30,12 @@ constexpr const char* PCIeMdrV2Path = "/xyz/openbmc_project/PCIe_MDRV2";
 constexpr const char* PCIeMdrV2Interface = "xyz.openbmc_project.PCIe_MDRV2";
 constexpr const char* PCIeMdrV2UpdateFunctionName = "UpdateMappingsFromFile";
 constexpr const char* PCIeDevicesPath = "/xyz/openbmc_project/inventory/pcie";
+
+constexpr const char* mapperBusName = "xyz.openbmc_project.ObjectMapper";
+constexpr const char* mapperPath = "/xyz/openbmc_project/object_mapper";
+constexpr const char* mapperInterface = "xyz.openbmc_project.ObjectMapper";
+
+constexpr const char* defaultInventoryPath =
+    "/xyz/openbmc_project/inventory/system";
+constexpr const char* systemInterface =
+    "xyz.openbmc_project.Inventory.Item.System";

--- a/include/pcie.hpp
+++ b/include/pcie.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "mdrv2.hpp"
 
+#include <xyz/openbmc_project/Association/Definitions/server.hpp>
 #include <xyz/openbmc_project/Inventory/Decorator/Asset/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/PCIeDevice/server.hpp>
 #include <xyz/openbmc_project/Inventory/Item/PCIeSlot/server.hpp>
@@ -66,12 +67,15 @@ using asset =
 using state = sdbusplus::server::xyz::openbmc_project::state::decorator::
     OperationalStatus;
 using item = sdbusplus::server::xyz::openbmc_project::inventory::Item;
+using association =
+    sdbusplus::server::xyz::openbmc_project::association::Definitions;
 
 class PcieDevice :
     sdbusplus::server::object_t<pcie_device>,
     sdbusplus::server::object_t<asset>,
     sdbusplus::server::object_t<state>,
-    sdbusplus::server::object_t<item>
+    sdbusplus::server::object_t<item>,
+    sdbusplus::server::object_t<association>
 {
   public:
     PcieDevice() = delete;
@@ -85,13 +89,14 @@ class PcieDevice :
         sdbusplus::server::object_t<pcie_device>(bus, objPath.c_str()),
         sdbusplus::server::object_t<asset>(bus, objPath.c_str()),
         sdbusplus::server::object_t<state>(bus, objPath.c_str()),
-        sdbusplus::server::object_t<item>(bus, objPath.c_str())
+        sdbusplus::server::object_t<item>(bus, objPath.c_str()),
+        sdbusplus::server::object_t<association>(bus, objPath.c_str())
     {
         for (int i = 0; i < pcieFunctionsSize; i++)
             configData[i] = nullptr;
     }
 
-    void pcieInfoUpdate();
+    void pcieInfoUpdate(const std::string& motherboard);
 
     std::array<uint8_t*, pcieFunctionsSize> configData;
 };

--- a/src/mdrv2.cpp
+++ b/src/mdrv2.cpp
@@ -3,14 +3,17 @@
 #include "pcie.hpp"
 
 #include <boost/asio/io_context.hpp>
+#include <boost/container/flat_map.hpp>
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/asio/connection.hpp>
 #include <sdbusplus/asio/object_server.hpp>
 
 #include <fstream>
 
 std::unordered_map<std::string, std::unique_ptr<PcieDevice>> pcieDevices;
+std::unique_ptr<sdbusplus::bus::match_t> motherboardConfigMatch;
 boost::asio::io_context io;
 
 bool readDataFromFlash(MDRPCIeHeader* mdrHdr, uint8_t* data)
@@ -65,7 +68,8 @@ bool readDataFromFlash(MDRPCIeHeader* mdrHdr, uint8_t* data)
     return true;
 }
 
-void updatePcieInfo(UpdateDBusData infoPcieDevs)
+void updatePcieInfo(UpdateDBusData infoPcieDevs,
+                    const std::string motherboardPath)
 {
     pcieDevices.clear();
     uint32_t offset = 0;
@@ -119,11 +123,11 @@ void updatePcieInfo(UpdateDBusData infoPcieDevs)
 
     for (auto& pciDev : pcieDevices)
     {
-        pciDev.second->pcieInfoUpdate();
+        pciDev.second->pcieInfoUpdate(motherboardPath);
     }
 }
 
-bool updateMappingsFromFile(sdbusplus::bus_t& bus)
+bool updateMappingsFromFile(sdbusplus::bus_t& bus, std::string motherboardPath)
 {
     UpdateDBusData infoPcieDevs;
     infoPcieDevs.bus = &bus;
@@ -143,25 +147,89 @@ bool updateMappingsFromFile(sdbusplus::bus_t& bus)
     if (infoPcieDevs.mdrHdr.dataSize < sizeof(PCIHeaderMDRV))
         return false;
 
-    io.post(std::bind(updatePcieInfo, infoPcieDevs));
+    io.post(std::bind(updatePcieInfo, infoPcieDevs, motherboardPath));
     return true;
+}
+
+void getMotherboardPath(sdbusplus::bus_t& bus, std::string& motherboardPath)
+{
+    std::vector<std::string> paths;
+
+    auto method = bus.new_method_call(mapperBusName, mapperPath,
+                                      mapperInterface, "GetSubTreePaths");
+    method.append(defaultInventoryPath);
+    method.append(0);
+    method.append(std::vector<std::string>({systemInterface}));
+
+    try
+    {
+        std::vector<std::string> paths;
+        sdbusplus::message_t reply = bus.call(method);
+        reply.read(paths);
+        if (paths.size() != 0)
+        {
+            motherboardPath = std::move(paths[0]);
+            return;
+        }
+    }
+    catch (const sdbusplus::exception_t& e)
+    {
+        // There might be a case when the interface is just created but
+        // ObjectMapper is unaware of this. Ignore this exception as
+        // an result of race conditions at system startup or reboot.
+        // Fallthrough to error case.
+    }
+
+    // Fallthrough in case of zero path.size() or d-bus exception:
+    // there is no need for specific condition.
+
+    phosphor::logging::log<phosphor::logging::level::ERR>(
+        "Failed to get system motherboard dbus path. Setting up a "
+        "match rule");
+    // Add match rule if motherboard dbus path is not yet created
+    static std::unique_ptr<sdbusplus::bus::match_t> motherboardConfigMatch =
+        std::make_unique<sdbusplus::bus::match_t>(
+            bus,
+            sdbusplus::bus::match::rules::interfacesAdded() +
+                sdbusplus::bus::match::rules::argNpath(
+                    0, std::string(defaultInventoryPath) + "/chassis/"),
+            [&](sdbusplus::message_t& msg) {
+        sdbusplus::message::object_path objectName;
+        boost::container::flat_map<
+            std::string, boost::container::flat_map<
+                             std::string, std::variant<std::string, uint64_t>>>
+            msgData;
+        msg.read(objectName, msgData);
+        if (msgData.contains(systemInterface))
+        {
+            // There is a defintion of the motherboard chassis:
+            // the only object having Item.System interface.
+            // Threfore without any scruples get the motherboard path from the
+            // match message.
+            motherboardPath = objectName;
+            updateMappingsFromFile(bus, motherboardPath);
+        }
+    });
 }
 
 int main(void)
 {
     auto connection = std::make_shared<sdbusplus::asio::connection>(io);
     auto objServer = sdbusplus::asio::object_server(connection);
-
     sdbusplus::bus_t& bus = static_cast<sdbusplus::bus_t&>(*connection);
+
+    std::string motherboardPath;
+    getMotherboardPath(bus, motherboardPath);
 
     bus.request_name(PCIeMdrV2Service);
     std::shared_ptr<sdbusplus::asio::dbus_interface> iface =
         objServer.add_interface(PCIeMdrV2Path, PCIeMdrV2Interface);
-    iface->register_method(PCIeMdrV2UpdateFunctionName,
-                           [&]() { return updateMappingsFromFile(bus); });
+    iface->register_method(PCIeMdrV2UpdateFunctionName, [&]() {
+        return updateMappingsFromFile(bus, motherboardPath);
+    });
     iface->initialize();
 
-    updateMappingsFromFile(bus);
+    updateMappingsFromFile(bus, motherboardPath);
 
     io.run();
 

--- a/src/pcie.cpp
+++ b/src/pcie.cpp
@@ -64,7 +64,7 @@ uint8_t findPCIeCapability(uint8_t* configData)
     return 0;
 }
 
-void PcieDevice::pcieInfoUpdate()
+void PcieDevice::pcieInfoUpdate(const std::string& motherboardPath)
 {
     for (int i = 0; i < pcieFunctionsSize; i++)
     {
@@ -137,5 +137,13 @@ void PcieDevice::pcieInfoUpdate()
                 .first->second);
         functional(true);
         present(true);
+
+        if (!motherboardPath.empty())
+        {
+            std::vector<std::tuple<std::string, std::string, std::string>>
+                assocs;
+            assocs.emplace_back("chassis", "pcie_devs", motherboardPath);
+            association::associations(assocs);
+        }
     }
 }


### PR DESCRIPTION
Adds motherboard associations support for PCIe devs. 
Creates association endpoint between PCIe device and available motherboard chassis.
Reworks match handler, so that updateMappingsFromFile() is called not from the match handler context. Decreases the number of recursion levels.
